### PR TITLE
BF: @data -> @misc for doi_bibtex.ftl

### DIFF
--- a/src/main/resources/freemarker/doi_bibtex.ftl
+++ b/src/main/resources/freemarker/doi_bibtex.ftl
@@ -1,4 +1,4 @@
-@data{${randomId},
+@misc{${randomId},
   doi = {${doi}},
   url = {http://dx.doi.org/${doi}},
   author = {<#list creators! as c>${c}; </#list>},


### PR DESCRIPTION
@data is not widely supported (if at all) by bibtex processors.
Thus it would be more appropriate to use @misc

Relates to discussion in #4 