### PR TITLE
fix: join bibtex author names with ` and `

### DIFF
--- a/src/main/resources/freemarker/doi_bibtex.ftl
+++ b/src/main/resources/freemarker/doi_bibtex.ftl
@@ -1,7 +1,7 @@
 @data{${randomId},
   doi = {${doi}},
   url = {http://dx.doi.org/${doi}},
-  author = {<#list creators! as c>${c}; </#list>},
+  author = {${creators?join(" and ")}},
   publisher = {${publisher!}},
   title = {${titles[0].value}},
   year = {${publicationYear!}}


### PR DESCRIPTION
Note that I don't know FreeMarker and this change is untested.

Uses the [sequence join](http://freemarker.org/docs/ref_builtins_sequence.html#ref_builtin_join)

Attempts to address the bibtex author name issue mentioned in https://github.com/datacite/content-resolver/issues/4#issuecomment-215505211

> As you note, there is another problem with DataCite bibtex: author names are not parsed correctly.
